### PR TITLE
Memory increases after each page reload. 

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -8,8 +8,8 @@
 
 <script>
 import get from 'lodash-es/get'
-import DefaultLayout from './layouts/Default'
-import MinimalLayout from './layouts/Minimal'
+const DefaultLayout = () => import(/* webpackChunkName: "vsf-layout-default" */ './layouts/Default')
+const MinimalLayout = () => import(/* webpackChunkName: "vsf-layout-minimal" */ './layouts/Minimal')
 
 export default {
   components: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed / Improved
 
 - Adjusted the error page (#398)
-
+- Fixed memory leak (#419)
 ## [1.0.2] - 03.07.2020
 
 ### Added


### PR DESCRIPTION
## Current behavior
<!--  Describe the current behavior pointing exactly why it's not working as intended. -->
Memory is never released and thus memory usage keeps increasing after each page reload.
In the default VSF theme the template imports are tagged with webpackChunkName and thus dynamically imported, in the Capybara theme however the imports are missing the webpackChunkName comment, which seems to cause the memory leak.

## Expected behavior
<!-- Describe what the desired behavior should be. -->
GC reclaims unused memory.

## Steps to reproduce the issue
<!-- Please provide the steps to reproduce and if possible a *minimal reproducible example* of the problem -->
1. Install the latest VSF with the Capybara theme in Docker.
2. Run, configure and import the demo data set
3. Run 'docker stats'
4. Browse to your vsf instance and keep reloading the page.
5. You should see the memory usage of your vsf container increase with each reload.

## Can you handle fixing this bug by yourself?

- [X ] YES
- [ ] NO

## Environment details
<!-- Please provide all the informations required below. -->
- Browser: Firefox 78.0.2 (64-bits)
- OS: Windows 10 pro 2006
- Code Version: latest Master (1.0.3)

## Additional information
<!-- If you think that any additional information would be useful, please provide them here. -->

