### PR TITLE
Improved: Consistency of profile icon (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved spacing around product carousal on home page(#471)
 - Improved navbar layout (#467)
 - Improved heading in search panel (#478)
+- Improved: Consistency of profile icon (#553)
 
 ## [1.0.3] - 20.09.2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved spacing around product carousal on home page(#471)
 - Improved navbar layout (#467)
 - Improved heading in search panel (#478)
-- Improved: Consistency of profile icon (#553)
 
 ## [1.0.3] - 20.09.2020
 

--- a/components/organisms/o-bottom-navigation.vue
+++ b/components/organisms/o-bottom-navigation.vue
@@ -34,7 +34,7 @@ export default {
         { icon: 'home', label: this.$t('Home'), onClick: this.goToHome },
         { icon: 'menu', label: this.$t('Menu'), onClick: this.goToMenu },
         { icon: 'search', label: this.$t('Search'), onClick: this.goToSearch },
-        { icon: 'profile', label: this.$t('Profile'), onClick: this.goToAccount },
+        { icon: 'account', label: this.$t('Profile'), onClick: this.goToAccount },
         { icon: 'add_to_cart', label: this.$t('Cart'), onClick: this.goToCart, isFloating: true }
       ]
     }


### PR DESCRIPTION
Replaced icon from 'account' to 'profile', this made the icon for my account consistent for mobile and desktop view

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #553 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

Replaced icon from 'account' to 'profile', this made the icon for my account consistent for mobile and desktop view

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before

![Screenshot from 2020-12-26 14-56-31](https://user-images.githubusercontent.com/8766155/103148968-5f4f7080-478b-11eb-8a76-12b0ca9e83cf.png)


After


![Screenshot from 2020-12-26 14-56-39](https://user-images.githubusercontent.com/8766155/103148969-60809d80-478b-11eb-86bb-7d22e4798100.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)