### PR TITLE
Updated: code to make the tab index work on the authentication modals(#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - UNRELEASED
+
+### Changed / Improved
+- Updated: code to make the tab index work on the authentication modals(#434)
+
 ## [1.0.4] - 04.01.2020
 
 ### Added

--- a/components/molecules/modals/m-modal-authentication.vue
+++ b/components/molecules/modals/m-modal-authentication.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="m-modal-authentication">
     <SfModal :visible="isVisible" @close="closeModal">
-      <transition name="fade" mode="out-in">
+      <transition name="fade">
         <MLogin v-if="modalData.payload === 'login'" />
         <MRegister v-if="modalData.payload === 'register'" />
         <MResetPassword v-if="modalData.payload === 'forgot-pass'" />
@@ -37,3 +37,16 @@ export default {
   }
 };
 </script>
+
+<style lang="scss" scoped>
+.fade-enter-active {
+  transition: opacity .5s ease-in;
+}
+.fade-leave-to {
+  transition: opacity 0s ease-out;
+}
+.fade-enter, .fade-leave-to {
+  position: absolute;
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
### Related Issues
#434 

Closes #434 

### Short Description and Why It's Useful
Removed the mode from the transition and used the transition classes.

### Screenshots of Visual Changes before/after (If There Are Any)

<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:

https://user-images.githubusercontent.com/41404838/105496242-39ae7c00-5ce3-11eb-8289-d406cf812241.mov



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)