### PR TITLE
Refactored m-update-password styling (#606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `VueObserveVisibility` and `VueLazyload` dependency
 
+### Changed / Improved
+- Improved css styling by replacing flexbox to css grid(#606)
+- Improved spacing between the form elements through grid gap(#606)
+- Improved button width on desktop(#606)
+- Improved line height of message text(#606)
+- Removed styling of 'a' tag as their was no 'a' tag in the file(#606)
+- Improved HTML markup by spacing between elements(#606)
+- Improved CSS styling by using shorthand methods (#606)
+
 ## [1.0.4] - 04.01.2020
 
 ### Added

--- a/components/molecules/m-update-password.vue
+++ b/components/molecules/m-update-password.vue
@@ -4,33 +4,35 @@
       {{ $t('If you want to change the password to access your account, enter the following information:') }}<br>
       <template v-if="currentUser">
         {{ $t('Your current email address is') }}
-        <span class="message__label">{{ typeof currentUser.email !== 'undefined' ? currentUser.email : '' }}</span>
+        <span>{{ typeof currentUser.email !== 'undefined' ? currentUser.email : '' }}</span>
       </template>
     </p>
+
     <div class="form">
       <SfInput
         v-model="oldPassword"
         type="password"
+        class="current-password"
         name="currentPassword"
         :label="$t('Current Password')"
         required
         :valid="!$v.oldPassword.$error"
         :error-message="$t('Field is required.')"
-        class="form__element"
       />
       <SfInput
         v-model="password"
         type="password"
+        class="new-password"
         name="newPassword"
         :label="$t('New Password')"
         required
         :valid="!$v.password.$error"
         :error-message="$t('Field is required.')"
-        class="form__element form__element--half"
       />
       <SfInput
         v-model="rPassword"
         type="password"
+        class="repeat-password"
         name="repeatPassword"
         :label="$t('Repeat Password')"
         required
@@ -40,9 +42,9 @@
             ? $t('Field is required.')
             : $t('Passwords must be identical.')
         "
-        class="form__element form__element--half form__element--half-even"
       />
-      <SfButton class="form__button" @click.native="updatePassword">
+
+      <SfButton class="action" @click.native="updatePassword">
         {{ $t('Update password') }}
       </SfButton>
     </div>
@@ -104,46 +106,36 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
-.form {
-  @include for-desktop {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-  &__element {
-    margin: 0 0 var(--spacer-lg) 0;
-    @include for-desktop {
-      flex: 0 0 100%;
-    }
-    &--half {
-      @include for-desktop {
-        flex: 1 1 50%;
-      }
-      &-even {
-        @include for-desktop {
-          padding: 0 0 0 var(--spacer-lg);
-        }
-      }
-    }
-  }
-  &__button {
-    --button-width: 100%;
-    @include for-desktop {
-      --button-width: auto;
-    }
-  }
-}
 .message {
-  margin: 0 0 var(--spacer-xl) 0;
+  margin-bottom: var(--spacer-xl);
   color: var(--c-dark-variant);
+  line-height: 1.4;
 }
-a {
-  color: var(--c-primary);
-  text-decoration: none;
-  &:hover {
-    color: var(--c-text);
+
+.form {
+  display: grid;
+  grid: "cpwd" "npwd" "rpwd";
+  grid-gap: var(--spacer-base) var(--spacer-lg);
+  align-items: center;
+}
+
+.current-password { grid-area: cpwd; }
+
+.new-password { grid-area: npwd; }
+
+.repeat-password { grid-area: rpwd; }
+
+@include for-desktop {
+  .form {
+    grid: "cpwd  cpwd"
+          "npwd  rpwd";
+  }
+
+  .action {
+    width: max-content;
   }
 }
 </style>

--- a/components/molecules/m-update-password.vue
+++ b/components/molecules/m-update-password.vue
@@ -110,28 +110,28 @@ export default {
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .message {
-  margin-bottom: var(--spacer-xl);
   color: var(--c-dark-variant);
   line-height: 1.4;
+  margin: 0 0 var(--spacer-xl) 0;
 }
 
 .form {
   display: grid;
-  grid: "cpwd" "npwd" "rpwd";
+  grid: "current" "new" "repeat";
   grid-gap: var(--spacer-base) var(--spacer-lg);
   align-items: center;
 }
 
-.current-password { grid-area: cpwd; }
+.current-password { grid-area: current; }
 
-.new-password { grid-area: npwd; }
+.new-password { grid-area: new; }
 
-.repeat-password { grid-area: rpwd; }
+.repeat-password { grid-area: repeat; }
 
 @include for-desktop {
   .form {
-    grid: "cpwd  cpwd"
-          "npwd  rpwd";
+    grid: "current  current"
+          "new      repeat";
   }
 
   .action {


### PR DESCRIPTION
### Related Issues
#606 

Closes #606 

### Short Description and Why It's Useful
Refactored styling of m-update-password


### Screenshots of Visual Changes before/after (If There Are Any)
![m-update-password-desktop-before](https://user-images.githubusercontent.com/82817616/116232505-d7e52e80-a777-11eb-8219-cf4fafc2c211.png)
![m-update-password-desktop-after](https://user-images.githubusercontent.com/82817616/116232548-e7647780-a777-11eb-99ec-e164a16cc6e2.png)
![m-update-password-mobile-before](https://user-images.githubusercontent.com/82817616/116232557-ea5f6800-a777-11eb-96d5-775ed81308da.png)
![m-update-password-mobile-after](https://user-images.githubusercontent.com/82817616/116232563-ecc1c200-a777-11eb-8e4e-997642ce4f08.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)