### PR TITLE
Refactored shipping details styling of o-my-account-shipping -details (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `VueObserveVisibility` and `VueLazyload` dependency
 
+### Changed / Improved
+- Improved css styling by replacing flexbox to css grid(#610)
+- Added auto fill property to grid column(#610)
+- Removed update button(#610)
+- Added update click functionality to address card itself(#610)
+- Improved delete button by using it with icon for deleting address on desktop also(#610)
+- Added hover effect to delete icon button(#610)
+- Improved HTML markup by spacing between elements(#610)
+
 ## [1.0.4] - 04.01.2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added auto fill property to grid column(#610)
 - Removed update button(#610)
 - Added update click functionality to address card itself(#610)
+- Added border to address card(#610)
 - Improved delete button by using it with icon for deleting address on desktop also(#610)
 - Added hover effect to delete icon button(#610)
 - Improved HTML markup by spacing between elements(#610)

--- a/components/organisms/o-my-account-shipping-details.vue
+++ b/components/organisms/o-my-account-shipping-details.vue
@@ -119,44 +119,43 @@
           <p class="message">
             {{ $t('Manage all the shipping addresses you want (work place, home address ...) This way you won\'t have to enter the shipping address manually with each order.') }}
           </p>
-          <transition-group tag="div" name="fade" class="shipping-list">
+
+          <transition-group tag="div" name="fade" class="address-list">
             <div
               v-for="(address, key) in addresses"
               :key="address.street.join(' ')"
-              class="shipping"
+              class="card"
             >
-              <div class="shipping__content">
-                <p class="shipping__address">
-                  <span class="shipping__client-name">{{ address.firstname }} {{ address.lastname }}</span><br>
-                  {{ address.street.join(' ') }}<br>
-                  {{ address.postcode }}
-                  {{ address.city }},<br>{{ getCountryById(address.country_id) }}
-                </p>
-                <p class="shipping__address">
-                  {{ address.telephone }}
-                </p>
-              </div>
-              <div class="shipping__actions">
+              <SfButton
+                @click="changeAddress(key)"
+                class="sf-button--pure sf-button--full-width update"
+              >
+                <div class="content">
+                  <p class="address">
+                    {{ address.firstname }} {{ address.lastname }}<br>
+                    {{ address.street.join(' ') }}<br>
+                    {{ address.postcode }}
+                    {{ address.city }},<br>{{ getCountryById(address.country_id) }}
+                  </p>
+                  <p class="address">
+                    {{ address.telephone }}
+                  </p>
+                </div>
+              </SfButton>
+
+              <SfButton
+                @click="deleteAddress(key)"
+                class="sf-button--pure delete"
+              >
                 <SfIcon
                   icon="cross"
                   color="gray"
-                  size="14px"
-                  role="button"
-                  class="mobile-only"
-                  @click="deleteAddress(key)"
+                  size="xxs"
                 />
-                <SfButton @click="changeAddress(key)">
-                  {{ $t('Change') }}
-                </SfButton>
-                <SfButton
-                  class="shipping__button-delete desktop-only"
-                  @click="deleteAddress(key)"
-                >
-                  {{ $t('Delete') }}
-                </SfButton>
-              </div>
+              </SfButton>
             </div>
           </transition-group>
+
           <SfButton class="action-button" @click="changeAddress(-1)">
             {{ $t('Add new address') }}
           </SfButton>
@@ -309,51 +308,49 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
-.shipping-list {
-  margin: 0 0 var(--spacer-base) 0;
+.address-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(343px, 1fr));
+  grid-gap: var(--spacer-base) var(--spacer-lg);
+  margin-bottom: var(--spacer-base);
 }
-.shipping {
-  display: flex;
-  padding: var(--spacer-base) 0;
-  border: 1px solid var(--c-light);
-  border-width: 1px 0 0 0;
-  &:last-child {
-    border-width: 1px 0 1px 0;
+
+.card {
+  position: relative;
+  transition: box-shadow 150ms linear;
+  padding: var(--spacer-sm);
+
+  &:hover {
+    box-shadow: 0px 4px 35px 0px var(--c-light);
   }
-  &__content {
-    flex: 1;
-    color: var(--c-text);
-  }
-  &__actions {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-end;
-    @include for-desktop {
-      flex-direction: row;
-      justify-content: flex-end;
-      align-items: center;
-    }
-  }
-  &__button-delete {
-    --button-background: var(--c-light);
-    --button-color: var(--c-dark-variant);
-    &:hover {
-      --button-background: var(--_c-light-primary);
-    }
-    @include for-desktop {
-      margin: 0 0 0 var(--spacer-base);
-    }
-  }
-  &__address {
-    margin: 0 0 var(--spacer-base) 0;
-    &:last-child {
-      margin: 0;
+}
+
+.address {
+   font: var(--font-normal) var(--font-base) / 1.6 var(--font-family-primary);
+   color: var(--c-link);
+   margin: 0;
+}
+
+.update {
+  text-align: unset;
+  justify-content: unset;
+ }
+
+.delete {
+  position: absolute;
+  top: var(--spacer-sm);
+  right: var(--spacer-sm);
+
+  &:hover {
+    .sf-icon{
+      fill: var(--c-dark);
     }
   }
 }
+
 .tab-orphan {
   @include for-mobile {
     --tabs-content-border-width: 0;

--- a/components/organisms/o-my-account-shipping-details.vue
+++ b/components/organisms/o-my-account-shipping-details.vue
@@ -322,6 +322,7 @@ export default {
   position: relative;
   transition: box-shadow 150ms linear;
   padding: var(--spacer-sm);
+  border: 1px solid var(--c-light);
 
   &:hover {
     box-shadow: 0px 4px 35px 0px var(--c-light);


### PR DESCRIPTION
### Related Issues
#610 

Closes #610 

### Short Description and Why It's Useful
Refactored shipping details styling


### Screenshots of Visual Changes before/after (If There Are Any)
![shipping-address-desktop-before](https://user-images.githubusercontent.com/82817616/116428942-05f36d00-a863-11eb-91be-852a1f6b1bf5.png)
![shipping-address-desktop-after(2)](https://user-images.githubusercontent.com/82817616/116505908-b603bd00-a8d9-11eb-90d0-79e46d416287.png)
![shipping-address-mobile-before](https://user-images.githubusercontent.com/82817616/116428968-0be94e00-a863-11eb-9a37-0aa763d300b8.png)
![shipping-address-mobile-after(2)](https://user-images.githubusercontent.com/82817616/116506137-3e825d80-a8da-11eb-9afc-f30c8111c918.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)