### PR TITLE
Fixed the position of categories during scrolling in o-search-panel (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `VueObserveVisibility` and `VueLazyload` dependency
 
+### Changed / Improved
+- Removed auto overflow from o-search-panel(#613)
+- Added  auto overflow to container(#613)
+- Improved position of categories(#613)
+- Improved height of products(#613)
+- Updated padding of container on mobile(#613)
+- Updated padding values(#613)
+- Improved HTML markup by spacing between elements(#613)
+
 ## [1.0.4] - 04.01.2020
 
 ### Added

--- a/components/organisms/o-search-panel.vue
+++ b/components/organisms/o-search-panel.vue
@@ -196,7 +196,6 @@ export default {
     }
     @include for-mobile {
       flex-direction: column;
-      padding: 0 var(--spacer-sm);
     }
   }
 

--- a/components/organisms/o-search-panel.vue
+++ b/components/organisms/o-search-panel.vue
@@ -158,6 +158,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .o-search-panel {
@@ -166,7 +167,6 @@ export default {
   right: 0;
   top: var(--_header-height);
   background: var(--c-white);
-  overflow: auto;
   max-height: calc(66vh - var(--_header-height));
 
   @include for-mobile {
@@ -175,6 +175,8 @@ export default {
   }
 
   .container {
+    max-height: inherit;
+    overflow: auto;
     display: flex;
     padding: 0 var(--spacer-sm);
     max-width: 1272px;
@@ -190,6 +192,8 @@ export default {
 
   .categories {
     @include for-desktop {
+      position: sticky;
+      top: 0;
       flex: 0 0 20%;
       padding-right: 3rem;
       border-right: 1px solid var(--c-light);
@@ -217,6 +221,7 @@ export default {
 
   .products {
     width: 100%;
+    height: max-content;
     &__title {
       padding: 0;
       justify-content: start;

--- a/components/organisms/o-search-panel.vue
+++ b/components/organisms/o-search-panel.vue
@@ -6,6 +6,7 @@
     >
       {{ $t(noResultsMessage) }}
     </div>
+
     <div v-else class="container">
       <div class="categories">
         <SfHeading :level="3" :title="$t('Categories')" class="categories__title sf-heading--left" />
@@ -23,6 +24,7 @@
           </SfListItem>
         </SfList>
       </div>
+
       <div class="products">
         <SfHeading :level="3" :title="$t('Product suggestions')" class="products__title sf-heading--left" />
         <div class="products__listing">
@@ -42,6 +44,7 @@
             @click.native="$store.commit('ui/setSearchpanel', false)"
           />
         </div>
+
         <SfButton
           v-if="OnlineOnly && readMore && visibleProducts.length >= pageSize"
           class="sf-button--full-width load-more"
@@ -174,6 +177,13 @@ export default {
     max-height: calc(100vh - var(--_header-height) - var(--bottom-navigation-height));
   }
 
+  .no-results {
+    height: 5rem;
+    line-height: 5rem;
+    display: flex;
+    justify-content: center;
+  }
+
   .container {
     max-height: inherit;
     overflow: auto;
@@ -186,7 +196,7 @@ export default {
     }
     @include for-mobile {
       flex-direction: column;
-      padding: 0 var(--spacer-xl);
+      padding: 0 var(--spacer-sm);
     }
   }
 
@@ -195,7 +205,7 @@ export default {
       position: sticky;
       top: 0;
       flex: 0 0 20%;
-      padding-right: 3rem;
+      padding-right: var(--spacer-xl);
       border-right: 1px solid var(--c-light);
     }
 
@@ -206,11 +216,11 @@ export default {
     }
     &__listing {
       @include for-desktop {
-        margin-top: 2rem;
+        margin-top: var(--spacer-lg);
       }
 
       .sf-list__item {
-        padding: 0.3rem 0;
+        padding: var(--spacer-2xs) 0;
       }
       .sf-menu-item.selected {
         --menu-item-font-weight: 500;
@@ -239,15 +249,8 @@ export default {
     }
 
     @include for-desktop {
-      padding-left: 3rem;
+      padding-left: var(--spacer-xl);
     }
-  }
-
-  .no-results {
-    height: 5rem;
-    line-height: 5rem;
-    display: flex;
-    justify-content: center;
   }
 
   .load-more {


### PR DESCRIPTION
### Related Issues
#613 

Closes #613 

### Short Description and Why It's Useful
Fixed the position of categories during scrolling in o-search-panel


### Screenshots of Visual Changes before/after (If There Are Any)
![o-search-panel-desktop-before(1)](https://user-images.githubusercontent.com/82817616/116683820-c1d0ab80-a9cd-11eb-9925-b0eb5b917a9b.png)

![o-search-panel-desktop-before(2)](https://user-images.githubusercontent.com/82817616/116683836-c5fcc900-a9cd-11eb-9496-3ba3b7b52be3.png)

![o-search-panel-desktop-after(1)](https://user-images.githubusercontent.com/82817616/116683846-c85f2300-a9cd-11eb-8886-1a0b4e7b6cd2.png)

![o-search-panel-desktop-after(2)](https://user-images.githubusercontent.com/82817616/116683855-cb5a1380-a9cd-11eb-81a6-57ade08621bd.png)

![o-search-panel-mobile-before](https://user-images.githubusercontent.com/82817616/116683867-ce550400-a9cd-11eb-9c86-76f71a62a1ef.png)

![o-search-panel-mobile-after](https://user-images.githubusercontent.com/82817616/116683873-d14ff480-a9cd-11eb-9292-6c33aa1d822b.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)