### PR TITLE
fix: wrong product img on PDP after clicked on filtered product from PLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: modalComponents map type errors
 - Fixed: remove product from Cart on Desktop
 - Fixed: close Mega Menu after clicking on the Category
+- Fixed: wrong product image on PDP after clicked on filtered product from PLP
 
 ## [1.0.4] - 04.01.2020
 

--- a/components/molecules/m-product-gallery.vue
+++ b/components/molecules/m-product-gallery.vue
@@ -3,6 +3,7 @@
     <SfGallery
       ref="gallery"
       :images="gallery"
+      :current="currentIndex + 1"
     />
   </div>
 </template>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #643 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fix for displaying wrong order of product images on PDP after clicked on filtered product from PLP

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
**BEFORE**
![Zrzut ekranu 2021-06-9 o 15 35 39](https://user-images.githubusercontent.com/40273258/121364945-844e2f00-c938-11eb-9afe-f6555d2b942e.png)
**AFTER**

![Zrzut ekranu 2021-06-9 o 15 34 51](https://user-images.githubusercontent.com/40273258/121364913-7dbfb780-c938-11eb-8e93-0b04dde9139f.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)