### PR TITLE
fix: calculation prices after coupon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 - Fix broken mega menu. Requires [one change](https://github.com/vuestorefront/vsf-capybara/issues/509#issuecomment-862174222) in the config. ([#509](https://github.com/vuestorefront/vsf-capybara/issues/509))
-- Used helper for calculating product prices in Cart/Checkout
+- Using `getProductPrice` helper for calculating product prices in Cart/Checkout
 
 ## [1.0.4] - 04.01.2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 - Fix broken mega menu. Requires [one change](https://github.com/vuestorefront/vsf-capybara/issues/509#issuecomment-862174222) in the config. ([#509](https://github.com/vuestorefront/vsf-capybara/issues/509))
-
+- Used helper for calculating product prices in Cart/Checkout
 
 ## [1.0.4] - 04.01.2020
 

--- a/components/organisms/o-microcart-panel.vue
+++ b/components/organisms/o-microcart-panel.vue
@@ -21,7 +21,7 @@
               :image="getThumbnailForProductExtend(product)"
               :title="product.name"
               :regular-price=" formatPrice(getProductPrice(product).regular)"
-              :special-price="!!getProductPrice(product).special ? formatPrice(getProductPrice(product).special) : null"
+              :special-price="formatPrice(getProductPrice(product).special)"
               :stock="10"
               :qty="product.qty"
               class="collected-product"

--- a/components/organisms/o-microcart-panel.vue
+++ b/components/organisms/o-microcart-panel.vue
@@ -20,8 +20,8 @@
               :key="product.id"
               :image="getThumbnailForProductExtend(product)"
               :title="product.name"
-              :regular-price="getProductPrice(product).regular"
-              :special-price="getProductPrice(product).special"
+              :regular-price="!!getProductPrice(product).regular ? formatPrice(getProductPrice(product).regular) : null"
+              :special-price="!!getProductPrice(product).special ? formatPrice(getProductPrice(product).special) : null"
               :stock="10"
               :qty="product.qty"
               class="collected-product"
@@ -104,8 +104,8 @@
 import { mapState, mapGetters } from 'vuex';
 import { localizedRoute } from '@vue-storefront/core/lib/multistore';
 import { onlineHelper } from '@vue-storefront/core/helpers';
-import { getThumbnailForProduct } from '@vue-storefront/core/modules/cart/helpers';
-import { getProductPrice, getProductPriceFromTotals } from 'theme/helpers';
+import { getThumbnailForProduct, getProductPrice } from '@vue-storefront/core/modules/cart/helpers';
+import { price } from '@vue-storefront/core/filters';
 import VueOfflineMixin from 'vue-offline/mixin';
 import onEscapePress from '@vue-storefront/core/mixins/onEscapePress';
 
@@ -169,9 +169,10 @@ export default {
       return getThumbnailForProduct(product);
     },
     getProductPrice (product) {
-      return onlineHelper.isOnline && product.totals && product.totals.options
-        ? getProductPriceFromTotals(product)
-        : getProductPrice(product);
+      return getProductPrice(product)
+    },
+    formatPrice (value) {
+      return value ? price(value) : ''
     },
     getProductOptions (product) {
       return onlineHelper.isOnline && product.totals && product.totals.options

--- a/components/organisms/o-microcart-panel.vue
+++ b/components/organisms/o-microcart-panel.vue
@@ -20,7 +20,7 @@
               :key="product.id"
               :image="getThumbnailForProductExtend(product)"
               :title="product.name"
-              :regular-price="!!getProductPrice(product).regular ? formatPrice(getProductPrice(product).regular) : null"
+              :regular-price=" formatPrice(getProductPrice(product).regular)"
               :special-price="!!getProductPrice(product).special ? formatPrice(getProductPrice(product).special) : null"
               :stock="10"
               :qty="product.qty"

--- a/components/organisms/o-microcart-panel.vue
+++ b/components/organisms/o-microcart-panel.vue
@@ -20,7 +20,7 @@
               :key="product.id"
               :image="getThumbnailForProductExtend(product)"
               :title="product.name"
-              :regular-price=" formatPrice(getProductPrice(product).regular)"
+              :regular-price="formatPrice(getProductPrice(product).regular)"
               :special-price="formatPrice(getProductPrice(product).special)"
               :stock="10"
               :qty="product.qty"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes https://github.com/vuestorefront/vue-storefront/issues/4460

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Used new `getProductPrice` instead calculation in the vue component

Related PR: https://github.com/vuestorefront/vue-storefront/pull/5973

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)