### PR TITLE
Added: Min Height to main contect in the page (#503)

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -28,10 +28,13 @@ export default {
 <style lang="scss">
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 body {
-  --overlay-z-index: 1;
+  --overlay-z-index: 2;
   --sidebar-aside-z-index: 2;
   --sidebar-z-index: 2;
   --bottom-navigation-height: 3.75rem;
+  --footer-height: 345px;
+  --_header-height: 80px;
+  --_header-mobile-height: 50px;
   --select-dropdown-z-index: 2;
   --bar-height: 3.125rem;
   --notification-font-size: var(--font-sm);
@@ -49,7 +52,14 @@ body {
   .sf-select {
     &__dropdown {
       padding-bottom: env(safe-area-inset-bottom); //safe area padding for dropdown
-   }
+    }
+  }
+  .global--max-width {
+    min-height: calc(100vh - var(--_header-mobile-height) - var(--bottom-navigation-height));
+    @include for-desktop {
+      min-height: calc(100vh - var(--_header-height) - var(--footer-height));
+      max-width: 1272px;
+    }
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added safe Area of Elements in the Bottom Elements(#499)
 
 ### Changed / Improved
+- Added min height to the main content of the page (#503)
 - Made navbar visible while scrolling on mobile(#622)
 - Added background blur effect on mobile(#622)
 - Updated css styling by replacing flexbox to css grid(#601)
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: the error message for the zip-code field on shipping and payment page(#589)
 - Fixed spacing of a-product-quantity(#614)
 - Improved: Z-index for dropdowns(#536)
-- Improved: Height for the micro cart on mobile (#576) 
+- Improved: Height for the micro cart on mobile (#576)
 - Fixed body scroll issue when open micro cart (#482)
 - Improved speed of carousel in m-product-carousel(#623)
 


### PR DESCRIPTION
### Related Issues
#503 

Closes #503 

### Short Description and Why It's Useful
There was no minimum height for page which make footer come up in empty state so added min-height to global max height css rule and defined height for footer, header and header mobile.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)