### PR TITLE
Removed Horizontal Padding on product bottom section in product page (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added safe Area of Elements in the Bottom Elements(#499)
 
 ### Changed / Improved
+- Removed Horizontal Padding on product bottom section in product page (#534)
 - Made navbar visible while scrolling on mobile(#622)
 - Added background blur effect on mobile(#622)
 - Updated css styling by replacing flexbox to css grid(#601)

--- a/pages/Product.vue
+++ b/pages/Product.vue
@@ -244,7 +244,6 @@ export default {
 
 .product__bottom {
   box-sizing: border-box;
-  padding: 0 var(--spacer-sm);
   @include for-desktop {
     padding: 0;
     max-width: 1272px;


### PR DESCRIPTION
### Related Issues
#534 

Closes #534 

### Short Description and Why It's Useful
Removed that padding for consistent behaviour.


### Screenshots of Visual Changes before/after (If There Are Any)
![oie_qI9lSchy1G5r](https://user-images.githubusercontent.com/82817616/132665299-79cde221-daad-4d10-990c-3bb868067836.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)